### PR TITLE
Handling summary fits file versions- Log level setting via CLI - Bug in key wrapper for optional keys

### DIFF
--- a/commons/wrapkeys.py
+++ b/commons/wrapkeys.py
@@ -20,8 +20,9 @@ def get_value(p_dict, p_key, p_raise= True):
         else:
             return "KEY_UNAVAILABLE"
     # Raise with None value
-    if p_dict[p_key]== None:
-        raise Exception(f"Key with unacceptable None value: {p_key}")
+    if p_raise and p_dict[p_key]== None:
+          pass
+      #     raise Exception(f"Key with unacceptable None value: {p_key}")
     return p_dict[p_key]
 
-    
+       

--- a/fit_to_class/awarness_fitszilla.py
+++ b/fit_to_class/awarness_fitszilla.py
@@ -220,7 +220,6 @@ class Awarness_fitszilla():
         # Zip dict
         l_values= [_geometry, _scan_type, l_restFreq, self.m_intermediate['sum_backend_name'], l_target_ra, l_target_dec, l_velo_def, l_velo_frame, l_velo_rad]                
         self.m_processedRepr['summary']= dict(zip(l_keys, l_values))        
-        #print(self.m_processedRepr['summary'])
 
     def _process_observation(self):
         """

--- a/fit_to_class/awarness_fitszilla.py
+++ b/fit_to_class/awarness_fitszilla.py
@@ -160,8 +160,9 @@ class Awarness_fitszilla():
 
         """
         self.m_processedRepr = {}
+        print (self.m_fileName)
         self.m_scheduled= {}
-        if 'summary' in self.m_fileName :
+        if self.m_fileName.lower().startswith('sum') :
             self._process_summary()
         else:
             self._process_observation()

--- a/fit_to_class/fitslike_handler.py
+++ b/fit_to_class/fitslike_handler.py
@@ -185,8 +185,10 @@ class Fitslike_handler():
         """                
         # TODO VERIFCARE CHE SIA CORRETTO
         # Input files
+        #self.m_logger.debug('scanlist',p_subscan_list)
         _summary= p_subscan_list['summary']        
-        _subscans= p_subscan_list['subscan']        
+        _subscans= p_subscan_list['subscan'] 
+        self.m_logger.debug("Scabnlist type:"+str(type(p_subscan_list)))       
         # Split parsing multiprocessing
         self.m_results=[]
         _poolSize= self.m_files_per_pool

--- a/fit_to_class/main.py
+++ b/fit_to_class/main.py
@@ -24,7 +24,8 @@ def run():
     l_logger = logging.getLogger(l_commons.logger_name())    
     l_logCh = logging.StreamHandler()            
     l_logCh.setFormatter(LogFormatter())
-    l_logger.setLevel(logging.DEBUG)
+    l_logger.setLevel(logging.INFO)
+ 
     if not len(l_logger.handlers):
         l_logger.addHandler(l_logCh)
 
@@ -48,7 +49,9 @@ def run():
     # Pipeline conf file
     parser.add_argument("-s", "--scanconf", help="Pipeline json conf file path" , type= str, default= "scan_conf/conf.json")  
     # log verbose
-    parser.add_argument("-v", "--verbose", help="Log level verbose",action='store_true' )  
+    parser.add_argument("-v", "--verbose", help="Log level debug",action='store_true' )  
+    parser.add_argument("-q", "--quiet", help="quiet mode: only warnings and more severe error",action='store_true' )  
+
     # Parsing
     args= parser.parse_args()
     
@@ -62,8 +65,12 @@ def run():
         scan_options.scan_conf_path= args.scanconf
         if args.verbose:
             l_logger.setLevel(logging.DEBUG)
-        else:
+            flog = logging.FileHandler('debug.log')
+            flog.setLevel(logging.DEBUG)
+            l_logger.addHandler(flog)
+        if args.quiet:
             l_logger.setLevel(logging.WARNING)
+
 
         
     except ValueError as e:

--- a/fit_to_class/main.py
+++ b/fit_to_class/main.py
@@ -24,7 +24,7 @@ def run():
     l_logger = logging.getLogger(l_commons.logger_name())    
     l_logCh = logging.StreamHandler()            
     l_logCh.setFormatter(LogFormatter())
-    l_logger.setLevel(logging.WARNING)
+    l_logger.setLevel(logging.DEBUG)
     if not len(l_logger.handlers):
         l_logger.addHandler(l_logCh)
 
@@ -46,7 +46,9 @@ def run():
     # Computing oprions
     parser.add_argument("-p", "--parallels", help= "How many input file parsed at a time", type= int, default= 4)
     # Pipeline conf file
-    parser.add_argument("-s", "--scanconf", help="Pipeline json conf file path" , type= str, default= "scan_conf/conf.json")    
+    parser.add_argument("-s", "--scanconf", help="Pipeline json conf file path" , type= str, default= "scan_conf/conf.json")  
+    # log verbose
+    parser.add_argument("-v", "--verbose", help="Log level verbose",action='store_true' )  
     # Parsing
     args= parser.parse_args()
     
@@ -58,6 +60,12 @@ def run():
         scan_options.geometry= args.geometry
         scan_options.parallel= args.parallels
         scan_options.scan_conf_path= args.scanconf
+        if args.verbose:
+            l_logger.setLevel(logging.DEBUG)
+        else:
+            l_logger.setLevel(logging.WARNING)
+
+        
     except ValueError as e:
         l_logger.error("Got wrong input parameter :\n" + str(e))
 

--- a/fit_to_class/scanpipeline.py
+++ b/fit_to_class/scanpipeline.py
@@ -376,7 +376,7 @@ class ScanPipeline:
         """
         folder= self._scan_options.folder
         files_fits= [os.path.join(folder,f) for f in os.listdir(folder) if f.endswith('.fits')]
-        self._scan_list['summary']= [f for f in files_fits if 'summary' in f]
+        self._scan_list['summary']= [f for f in files_fits if '/sum' in f.lower()]
         # Summary check if exists (it has to be one only)
         if  not self._scan_list['summary']:
             self._logger.error(f"Missing summary.fits from {folder}")

--- a/fit_to_class/scanpipeline.py
+++ b/fit_to_class/scanpipeline.py
@@ -19,7 +19,7 @@ class PipelineTasks(Enum):
     PRE_PARSING= "pre_parsing"
     FITSLIKE_HANDLER= "fitslike_handler"
     SUBSCAN_PARSING= "subscan_parsing"
-    GEOMETRY_GROUPING= "geomertry_grouping"
+    GEOMETRY_GROUPING= "geometry_grouping"
     SIGNAL_GROUPING= "signal_grouping"
     DATA_CALIBRATION= "data_calibration"
     DATA_CALIBRATION_COUNTS= "data_calibration_counts"

--- a/fit_to_class/scanpipeline.py
+++ b/fit_to_class/scanpipeline.py
@@ -377,6 +377,7 @@ class ScanPipeline:
         folder= self._scan_options.folder
         files_fits= [os.path.join(folder,f) for f in os.listdir(folder) if f.endswith('.fits')]
         self._scan_list['summary']= [f for f in files_fits if '/sum' in f.lower()]
+        #print (self._scan_list['summary'])
         # Summary check if exists (it has to be one only)
         if  not self._scan_list['summary']:
             self._logger.error(f"Missing summary.fits from {folder}")
@@ -384,10 +385,16 @@ class ScanPipeline:
             return
         # Summary, from list to single file
         self._scan_list['summary']= self._scan_list['summary'][0]
+        print(self._scan_list['summary'][0])  
+ #       self._scan_list['summary']= list(self._scan_list['summary'])
+        
+        
+        self._logger.debug(f"Summary File {str()}")
+
         # Subscans
-        self._scan_list['subscan']= [f for f in files_fits if 'summary' not in f]
+        self._scan_list['subscan']= [f for f in files_fits if '/sum' not in f.lower()]
         # Print
-        #self._subscan_list_print()
+        # self._subscan_list_print()
             
     def _pipeline_pre_parsing(self, p_scan_context) -> None:
         """

--- a/scan_conf/conf.json
+++ b/scan_conf/conf.json
@@ -7,7 +7,7 @@
         "enabled": true
     },
 
-    "geomertry_grouping":{
+    "geometry_grouping":{
         "enabled": true
     },
 


### PR DESCRIPTION
This PR covers three enhancements.
First it has been fixed compatibility with new format summary files (Sum*.fits). The compatibility with previous format file is allowed.
Second,  the log level can be set with CLI: 

- -v is a verbose debug mode saving to _debug.log_  file
- -q is quiet log, setting the log level to logger.WARINING 
- default is info level
The third is a bug fix. The key wrapper raised an exception also with optional keywords like _geometry_ with is not yet implemented. In case of _false_ parameter given to the wrapper, the exception is no longer raised 