### PR TITLE
Fix issue 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ on the other hand when we need the usual calibrated data:
         "enabled": true
     }
 
+## Documentation
+
+Install [Sphinx](https://www.sphinx-doc.org/en/master/usage/installation.html).
+Once Sphinx is installed, run  `make html` from the fit2class `docs` directory.
+The documentation will be written in `docs/build/html`.
+
+
 ## release notes
 
 * 0.1 first commit

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,48 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../..'))
+
+project = 'Fit2Class'
+copyright = '2023, Matteo De Biaggi, Sergio Poppi'
+author = 'Matteo De Biaggi, Sergio Poppi'
+release = '0.1'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+]
+
+# Napoleon settings
+napoleon_google_docstring = True
+napoleon_numpy_docstring = True
+napoleon_include_init_with_doc = True
+napoleon_include_private_with_doc = True
+napoleon_include_special_with_doc = True
+napoleon_use_admonition_for_examples = False
+napoleon_use_admonition_for_notes = False
+napoleon_use_admonition_for_references = False
+napoleon_use_ivar = False
+napoleon_use_param = True
+napoleon_use_rtype = True
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'alabaster'
+html_static_path = ['_static']

--- a/docs/source/fit_to_class.rst
+++ b/docs/source/fit_to_class.rst
@@ -1,0 +1,125 @@
+fit\_to\_class package
+======================
+
+Submodules
+----------
+
+fit\_to\_class.awarness\_fitszilla module
+-----------------------------------------
+
+.. automodule:: fit_to_class.awarness_fitszilla
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+fit\_to\_class.awarness\_fitszilla\_coord module
+------------------------------------------------
+
+.. automodule:: fit_to_class.awarness_fitszilla_coord
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+fit\_to\_class.fitslike module
+------------------------------
+
+.. automodule:: fit_to_class.fitslike
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+fit\_to\_class.fitslike\_commons module
+---------------------------------------
+
+.. automodule:: fit_to_class.fitslike_commons
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+fit\_to\_class.fitslike\_component module
+-----------------------------------------
+
+.. automodule:: fit_to_class.fitslike_component
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+fit\_to\_class.fitslike\_handler module
+---------------------------------------
+
+.. automodule:: fit_to_class.fitslike_handler
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+fit\_to\_class.fitslike\_keywords module
+----------------------------------------
+
+.. automodule:: fit_to_class.fitslike_keywords
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+fit\_to\_class.fitslike\_scangeometry module
+--------------------------------------------
+
+.. automodule:: fit_to_class.fitslike_scangeometry
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+fit\_to\_class.fitslike\_scantype module
+----------------------------------------
+
+.. automodule:: fit_to_class.fitslike_scantype
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+fit\_to\_class.fitslike\_tables module
+--------------------------------------
+
+.. automodule:: fit_to_class.fitslike_tables
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+fit\_to\_class.log\_formatter module
+------------------------------------
+
+.. automodule:: fit_to_class.log_formatter
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+fit\_to\_class.main module
+--------------------------
+
+.. automodule:: fit_to_class.main
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+fit\_to\_class.scanoptions module
+---------------------------------
+
+.. automodule:: fit_to_class.scanoptions
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+fit\_to\_class.scanpipeline module
+----------------------------------
+
+.. automodule:: fit_to_class.scanpipeline
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: fit_to_class
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,20 @@
+Fit2Class's documentation
+=========================
+
+.. $ sphinx-apidoc -f -o . ../../fit_to_class/
+.. Add the generated files here in index.rst
+.. $ make html
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   modules.rst
+   fit_to_class.rst
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -1,0 +1,7 @@
+fit_to_class
+============
+
+.. toctree::
+   :maxdepth: 4
+
+   fit_to_class


### PR DESCRIPTION
There are several warnings related to the wrong documentation markup in the code, but it works. Info to build the doc in README.md. Basically:

* Install Sphinx
* Move to docs and run `make html`
* You will find the doc generated in `docs/build/html`